### PR TITLE
Use CocoaPods CDN instead of git repo

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -87,7 +87,7 @@
         </config-file>
         <podspec>
             <config>
-                <source url="https://github.com/CocoaPods/Specs.git"/>
+                <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use_frameworks="true">
                 <pod name="MSAL" />


### PR DESCRIPTION
Significantly speeds up pod install, especially when using a CI Pipeline.