### PR TITLE
Update Android msal to v1.5

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,3 +1,6 @@
+repositories {
+    maven { url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed%40Local/maven/v1' }
+}
 dependencies {
-    implementation 'com.microsoft.identity.client:msal:1.4.+'
+    implementation 'com.microsoft.identity.client:msal:1.5.+'
 }


### PR DESCRIPTION
I would like to update to msal 1.5. It fixes an issue with the username in combination with B2C. With msal 1.4 the account.getUsername() returns "Missing from the token response". In 1.5 this is fixed and it returns the correct username