### PR TITLE
Return more account information

### DIFF
--- a/src/android/MsalPlugin.java
+++ b/src/android/MsalPlugin.java
@@ -284,10 +284,12 @@ public class MsalPlugin extends CordovaPlugin {
                     JSONArray accounts = new JSONArray();
                     try {
                         if (SINGLE_ACCOUNT.equals(accountMode)) {
-                            if (MsalPlugin.this.appSingleClient.getCurrentAccount().getCurrentAccount() == null) {
-                                MsalPlugin.this.callbackContext.error("No account currently exists");
-                            } else {
-                                accounts.put(MsalPlugin.this.appSingleClient.getCurrentAccount().getCurrentAccount().getId());
+                            IAccount account = MsalPlugin.this.appSingleClient.getCurrentAccount().getCurrentAccount();
+                            if (account != null) {
+                                JSONObject accountObj = new JSONObject();
+                                accountObj.put("id", account.getId());
+                                accountObj.put("username", account.getUsername());
+                                accounts.put(accountObj);
                             }
                         } else {
                             for (IAccount account : MsalPlugin.this.appMultipleClient.getAccounts()) {

--- a/src/android/MsalPlugin.java
+++ b/src/android/MsalPlugin.java
@@ -289,6 +289,7 @@ public class MsalPlugin extends CordovaPlugin {
                                 JSONObject accountObj = new JSONObject();
                                 accountObj.put("id", account.getId());
                                 accountObj.put("username", account.getUsername());
+                                accountObj.put("claims", new JSONObject(account.getClaims()));
                                 accounts.put(accountObj);
                             }
                         } else {
@@ -296,6 +297,7 @@ public class MsalPlugin extends CordovaPlugin {
                                 JSONObject accountObj = new JSONObject();
                                 accountObj.put("id", account.getId());
                                 accountObj.put("username", account.getUsername());
+                                accountObj.put("claims", new JSONObject(account.getClaims()));
                                 accounts.put(accountObj);
                             }
                         }

--- a/src/ios/MsalPlugin.m
+++ b/src/ios/MsalPlugin.m
@@ -117,7 +117,7 @@
         NSMutableArray<NSDictionary *> *accounts = [[NSMutableArray<NSDictionary *> alloc] init];
         for (MSALAccount *account in [[self application] allAccounts:nil])
         {
-            [accounts addObject:@{ @"id" : [account identifier], @"username" : [account username]}];
+            [accounts addObject:@{ @"id" : [account identifier], @"username" : [account username], @"claims" : [account accountClaims]}];
         }
         CDVPluginResult *result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:accounts];
         [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];


### PR DESCRIPTION
I would like to return the account information for single account in the same format as multiple accounts mode:

- Return id and **username**
- No exception in case there isn't any logged in user

Are you willing to accept this? It helps us with displaying the logged in user without being forced to use multiple account mode unnecessarily.

It looks like for ios there is only multiple account mode.