### PR TITLE
Add support for overriding the web view used for sign in

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,12 @@ Any consent prompts that the user accepted giving your app access to their accou
 This is an array of objects of type {param: string, value: string}, empty by default. There are lots of extra query string parameters that can be passed with MSAL signin requests, and if you know you need to add this you probably already know what you want to put here.
 ### otherScopesToAuthorize
 This is an array of strings just like the scopes array you may have provided when you first called msalInit (or maybe you just left it at ['User.Read']). The different here is that the vanilla scopes array only tells MSAL, programatically, which API scopes it's allowed to call when getting data. Users are not asked to consent to those scopes until something tries to use them, which can result in annoying prompts in the middle of using your app. If you provide these extra scopes here as well, the user will be asked to accept all of them at once when signing in and won't get bugged later, regardless of whether those scopes are actually used or not.
+### webViewType (iOS only)
+By default, MSAL picks a default web view type for sign in based on the version of iOS. For iOS 11 and up, this is an AuthenticationSession (ASWebAuthenticationSession or SFAuthenticationSession) which shows the "App wants to sign in with" permission dialog. If you do not require SSO and wish to avoid this permission dialog you can specify one of the other web view types to use - both of which avoid the permission dialog.
+#### 'SAFARI_VIEW_CONTROLLER'
+Use a Safari web view for the sign in.
+#### 'WK_WEB_VIEW'
+Use a plain WKWebView for sign in.
 
 Here's an example usage:
 ```js

--- a/src/ios/MsalPlugin.m
+++ b/src/ios/MsalPlugin.m
@@ -286,14 +286,13 @@
     else
     {
         MSALWebviewParameters *webParameters = [[MSALWebviewParameters alloc] initWithParentViewController:[self viewController]];
-
-        MSALInteractiveTokenParameters *interactiveParams = [[MSALInteractiveTokenParameters alloc] initWithScopes:[self scopes] webviewParameters:webParameters];
         
         NSError *err = nil;
         CDVPluginResult *result = nil;
         
         NSString *loginHint = (NSString *)[command.arguments objectAtIndex:0];
         NSString *prompt = (NSString *)[command.arguments objectAtIndex:1];
+        NSString *webViewType = (NSString *)[command.arguments objectAtIndex:4];
         
         if (err)
         {
@@ -301,6 +300,19 @@
             [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
             return;
         }
+        
+        if (![webViewType isEqual:[NSNull null]]) {
+            if ([webViewType isEqualToString:@"WK_WEB_VIEW"])
+            {
+                webParameters.webviewType = MSALWebviewTypeWKWebView;
+            }
+            if ([webViewType isEqualToString:@"SAFARI_VIEW_CONTROLLER"])
+            {
+                webParameters.webviewType = MSALWebviewTypeSafariViewController;
+            }
+        }
+
+        MSALInteractiveTokenParameters *interactiveParams = [[MSALInteractiveTokenParameters alloc] initWithScopes:[self scopes] webviewParameters:webParameters];
         
         if (![loginHint isEqual:[NSNull null]])
         {

--- a/www/msalplugin.js
+++ b/www/msalplugin.js
@@ -57,7 +57,8 @@ module.exports = {
             typeof(signInOptions.loginHint !== 'undefined') ? signInOptions.loginHint : '',
             typeof(signInOptions.prompt !== 'undefined') ? signInOptions.prompt : '',
             typeof(signInOptions.authorizationQueryStringParameters) !== 'undefined' ? signInOptions.authorizationQueryStringParameters : [],
-            typeof(signInOptions.otherScopesToAuthorize) !== 'undefined' ? signInOptions.otherScopesToAuthorize : []
+            typeof(signInOptions.otherScopesToAuthorize) !== 'undefined' ? signInOptions.otherScopesToAuthorize : [],
+            typeof(signInOptions.webViewType) !== 'undefined' ? signInOptions.webViewType : ''
         ];
         cordova.exec(successCallback, errorCallback, 'MsalPlugin', 'signInInteractive', opts);
     },


### PR DESCRIPTION
As per the [active directory docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/customize-webviews) there are a few web views supported in the MSAL iOS version. 

The default web view used supports single sign-on (SSO) and shows the "<AppName> wants to sign in with <B2C site host>" permission dialog. 

By using either the SafariViewController or WKWebView alternatives, this permission dialog can be avoided. However, when using the WKWebView version, we do sacrifice SSO.