### PR TITLE
Fixed malformed json on Android when providing multiple authorities.

### DIFF
--- a/src/android/MsalPlugin.java
+++ b/src/android/MsalPlugin.java
@@ -193,12 +193,16 @@ public class MsalPlugin extends CordovaPlugin {
                             authorities.append("          \"tenant_id\": \"" + MsalPlugin.this.tenantId + "\"\n");
                             authorities.append("        },\n");
                             if (authority.has("authorityUrl") && !authority.getString("authorityUrl").equals("")) {
-                                authorities.append("          \"authority_url\": \"" + authority.getString("authorityUrl") + "\",\n");
+                                authorities.append("        \"authority_url\": \"" + authority.getString("authorityUrl") + "\",\n");
                             }
                             if (authority.has("default")) {
-                                authorities.append("          \"default\": " + authority.getBoolean("default") + "\n");
+                                authorities.append("        \"default\": " + authority.getBoolean("default") + "\n");
                             }
-                            authorities.append("      }\n");
+                            if (i < authoritiesList.length() - 1) {
+                                authorities.append("      },\n");
+                            } else {
+                                authorities.append("      }\n");
+                            }
                         }
                         authorities.append("    ]\n");
                         data = "{\n" +


### PR DESCRIPTION
When providing multiple authorities on Android, the generated json is missing a comma between the list elements. This pull request fixes this. Some spaces has also been removed to properly align the data.

I don't know if this is also an issue on ios as I don't know objective c.