### PR TITLE
Correctly document cordova dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,14 @@
       "OutSystems",
       "ecosystem:cordova"
     ],
-    "dependencies": {
-      "cordova": "^7.0.0",
-      "cordova-android": "^8.1.0",
-      "cordova-ios": "^5.1.1"
+    "engines": {
+      "cordovaDependencies": {
+        "3.0.0": { 
+          "cordova-android": ">=8.1.0",
+          "cordova": ">=7.0.0",
+          "cordova-ios": ">=5.1.1"
+        }
+      }
     },
     "author": "Walter Robins <wrobins@kent.edu>",
     "license": "Apache 2.0",


### PR DESCRIPTION
Hi @wrobins 

Just noticed in passing that master moved the cordova requirements into the `"dependencies"` section, which suddenly starts installing a whole raft of additional packages.

I've tweaked this so it hopefully aligns as per https://cordova.apache.org/docs/en/10.x/guide/hybrid/plugins/index.html#specifying-cordova-dependencies .

Also, do you have a timeline for when an official release (or at least another alpha build) might drop?

Thanks for the work on the plugin here!