### PR TITLE
Ensure browser platform is initialised before modifying json config

### DIFF
--- a/src/scripts/after_prepare.js
+++ b/src/scripts/after_prepare.js
@@ -1,11 +1,10 @@
 const fs = require('fs');
 
-const config = JSON.parse(fs.readFileSync('platforms/browser/browser.json').toString());
-const CLIENT_ID = `'${config.installed_plugins["cordova-plugin-msal"].CLIENT_ID}'`;
-const TENANT_ID = `'${config.installed_plugins["cordova-plugin-msal"].TENANT_ID}'`;
-
 // If our application has the browser platform installed, this is ideally where we want to configure it.
 if (fs.existsSync('platforms/browser/browser.json')) {
+    const config = JSON.parse(fs.readFileSync('platforms/browser/browser.json').toString());
+    const CLIENT_ID = `'${config.installed_plugins["cordova-plugin-msal"].CLIENT_ID}'`;
+    const TENANT_ID = `'${config.installed_plugins["cordova-plugin-msal"].TENANT_ID}'`;
     const proxyFile = 'platforms/browser/www/plugins/cordova-plugin-msal/src/browser/MsalProxy.js';
     const contents = fs.readFileSync(proxyFile).toString();
     fs.writeFileSync(proxyFile, contents.replace(/CLIENT_ID/g, CLIENT_ID).replace(/TENANT_ID/g, TENANT_ID));


### PR DESCRIPTION
Another minor tweak... this avoids the following error when building without having the browser platform prepared:
```
Prepared android project successfully
Executing script found in plugin cordova-plugin-msal for hook "after_prepare": plugins\cordova-plugin-msal\src\scripts\after_prepare.js
ENOENT: no such file or directory, open 'platforms/browser/browser.json'
Error: ENOENT: no such file or directory, open 'platforms/browser/browser.json'
    at Object.openSync (fs.js:476:3)
    at Object.readFileSync (fs.js:377:35)
    at Object.<anonymous> (J:\work\mobile-aurelia-baseline\plugins\cordova-plugin-msal\src\scripts\after_prepare.js:3:30)
    at Module._compile (internal/modules/cjs/loader.js:1063:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1092:10)
    at Module.load (internal/modules/cjs/loader.js:928:32)
    at Function.Module._load (internal/modules/cjs/loader.js:769:14)
    at Module.require (internal/modules/cjs/loader.js:952:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at runScriptViaModuleLoader (J:\work\mobile-aurelia-baseline\node_modules\cordova-lib\src\hooks\HooksRunner.js:147:20)
    at runScript (J:\work\mobile-aurelia-baseline\node_modules\cordova-lib\src\hooks\HooksRunner.js:136:12)
    at J:\work\mobile-aurelia-baseline\node_modules\cordova-lib\src\hooks\HooksRunner.js:108:40
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```