### PR TITLE
Fix JSON arrays being handled incorrectly on Android

### DIFF
--- a/src/android/MsalPlugin.java
+++ b/src/android/MsalPlugin.java
@@ -562,15 +562,13 @@ public class MsalPlugin extends CordovaPlugin {
                 claimObj.put("key", claim.getKey());
                 if (claim.getValue() instanceof net.minidev.json.JSONArray) {
                   claimObj.put("value", new JSONArray(claim.getValue().toString()));
-                }
-                else if (claim.getValue() instanceof ArrayList) {
+                } else if (claim.getValue() instanceof ArrayList) {
                   JSONArray arr = new JSONArray();
                   for (Object obj: (ArrayList)claim.getValue()) {
                     arr.put(obj);
                   }
                   claimObj.put("value", arr);
-                }
-                else {
+                } else {
                   claimObj.put("value", claim.getValue());
                 }
                 claimsArr.put(claimObj);

--- a/src/android/MsalPlugin.java
+++ b/src/android/MsalPlugin.java
@@ -560,7 +560,19 @@ public class MsalPlugin extends CordovaPlugin {
             try {
                 JSONObject claimObj = new JSONObject();
                 claimObj.put("key", claim.getKey());
-                claimObj.put("value", claim.getValue());
+                if (claim.getValue() instanceof net.minidev.json.JSONArray) {
+                  claimObj.put("value", new JSONArray(claim.getValue().toString()));
+                }
+                else if (claim.getValue() instanceof ArrayList) {
+                  JSONArray arr = new JSONArray();
+                  for (Object obj: (ArrayList)claim.getValue()) {
+                    arr.put(obj);
+                  }
+                  claimObj.put("value", arr);
+                }
+                else {
+                  claimObj.put("value", claim.getValue());
+                }
                 claimsArr.put(claimObj);
             } catch (JSONException e) {
                 MsalPlugin.this.callbackContext.error(e.getMessage());


### PR DESCRIPTION
We discovered that on Android the JSON arrays were not coming down as such, and instead were incorrectly coming down as strings. This small change ensures that the arrays are not turned into strings. Specifically, this helps with claims such as `emails` which should be returning an array of email addresses. iOS was displaying the correct behaviour but Android was doing something different.
Hope you don't mind the PR as I think this will help others and keep the claim values consistent between platforms.
If you have any questions or issues with this let me know 💪 