### PR TITLE
Use the cordova framework element instead of raw gradle for specifying the library

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -53,6 +53,7 @@
         </config-file>
         <source-file src="src/android/MsalPlugin.java" target-dir="src/com/wrobins/cordova/plugin" />
         <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
+        <framework src="com.microsoft.identity.client:msal:4.1.+" />
     </platform>
     <platform name="ios">
         <config-file target="config.xml" parent="/*">

--- a/src/android/MsalPlugin.java
+++ b/src/android/MsalPlugin.java
@@ -562,9 +562,7 @@ public class MsalPlugin extends CordovaPlugin {
             try {
                 JSONObject claimObj = new JSONObject();
                 claimObj.put("key", claim.getKey());
-                if (claim.getValue() instanceof JSONArray) {
-                  claimObj.put("value", new JSONArray(claim.getValue().toString()));
-                } else if (claim.getValue() instanceof ArrayList) {
+                if (claim.getValue() instanceof ArrayList) {
                   JSONArray arr = new JSONArray();
                   for (Object obj: (ArrayList)claim.getValue()) {
                     arr.put(obj);

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,15 +1,5 @@
-android {
-    compileSdkVersion 33
-    defaultConfig {
-        minSdkVersion 26
-        targetSdkVersion 33
-    }
-}
 repositories {
     maven {
         url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
     }
-}
-dependencies {
-    implementation 'com.microsoft.identity.client:msal:4.1.+'
 }


### PR DESCRIPTION
I have removed the additional compile SDK and default config settings from the plugin to keep these under control of the integrating application instead.

Let me know if this is of any interest to you or not. Absolutely no problems if you prefer to keep the approach unchanged! 🙂 