### PR TITLE
Allow client and tenant IDs to be specified on msal init at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ If you aren't using AzureADMyOrg as one of your authorities, you can omit TENANT
 <pre>
 cordova plugin add cordova-plugin-msal --variable TENANT_ID=your-tenant-guid-here --variable CLIENT_ID=your-client-guid-here --variable KEY_HASH=S0m3K3yh4shH3re=
 </pre>
+Note that since the added support for multiple tentants/clients, you can now provide these IDs in via `msalInit` if they are not available at build time.
 ### If you're using OutSystems
 You should use my [forge component](https://www.outsystems.com/forge/Component_Overview.aspx?ProjectId=8038). But if you want to implement a wrapper yourself, or if you're here because you're using that component and you want additional documentation, continue reading:
 
@@ -291,6 +292,15 @@ window.cordova.plugins.msalPlugin.signInInteractive(mycbfunction(msg), myerrorfu
         authorizationQueryStringParameters: [{param: 'domain_hint', value: 'my-tenant-guid'}];
     }
 );
+```
+
+## Multiple tenants/client applications
+You can now provide your `tenantId` or `clientId` in directly to the `msalInit` function via the `options` object. This means that the plugin can support swapping between different tenants/clients on the fly just by re-initialising the plugin with the new IDs. This is useful if you want to support different geographical regions or tenants without having to rebuild the app for each different configuration.
+```js
+cordova.plugins.msalPlugin.msalInit(resolve, reject, {
+    ...
+    clientId: 'abcd1234-1111-2222-3333-eeeeeeffffff'
+});
 ```
 
 ## Logging/Debugging

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,6 +85,15 @@ interface InitOptions {
    */
   scopes: Array<string>;
 
+  /** Optional clientId and tenantId to support changing B2C tenants on the fly.
+   * 
+   * These values, if provided, will override the ones provided in your package.json file.
+   * If you do not wish to support multiple tenants, you can leave these out and the ones
+   * provided in your package.json will be used as they always were. No change required.
+   */
+  clientId?: string;
+  tenantId?: string;
+
   /** ANDROID ONLY: Optional zoom controls for defining web view behavior */
   webViewZoomControlsEnabled?: boolean;
   webViewZoomEnabled?: boolean;

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
         <clobbers target="cordova.plugins.msalPlugin" />
     </js-module>
     <preference name="TENANT_ID" default="common" />
-    <preference name="CLIENT_ID" />
+    <preference name="CLIENT_ID" default="00000000-0000-0000-0000-000000000000" />
     <preference name="KEY_HASH" default="not-provided" />
     <platform name="android">
         <config-file target="res/xml/config.xml" parent="/*">

--- a/src/android/MsalPlugin.java
+++ b/src/android/MsalPlugin.java
@@ -185,6 +185,12 @@ public class MsalPlugin extends CordovaPlugin {
                     StringBuilder authorities = new StringBuilder("    \"authorities\": [\n");
                     String data;
                     try {
+                        if (!"".equals(options.optString("tenantId"))) {
+                            MsalPlugin.this.tenantId = options.getString("tenantId");
+                        }
+                        if (!"".equals(options.optString("clientId"))) {
+                            MsalPlugin.this.clientId = options.getString("clientId");
+                        }
                         JSONArray authoritiesList = options.getJSONArray("authorities");
                         for (int i = 0; i < authoritiesList.length(); ++i) {
                             JSONObject authority = authoritiesList.getJSONObject(i);

--- a/src/browser/MsalProxy.js
+++ b/src/browser/MsalProxy.js
@@ -16,8 +16,8 @@ let accountMode = 'SINGLE';
 function msalInit(success, error, opts) {
     try {
         const providedConfig = JSON.parse(opts[0]);
-        msalConfig.auth.clientId = clientID;
-        msalConfig.auth.authority = `https://login.microsoftonline.com/${tenantId}`;
+        msalConfig.auth.clientId = providedConfig.clientId || clientID;
+        msalConfig.auth.authority = `https://login.microsoftonline.com/${providedConfig.tenantId || tenantId}`;
         msalConfig.auth.knownAuthorities = providedConfig.authorities.filter(a => a.authorityUrl !== '').map(a => a.authorityUrl);
         accountMode = providedConfig.accountMode;
         loginRequest.scopes = providedConfig.scopes;

--- a/src/ios/MsalPlugin.m
+++ b/src/ios/MsalPlugin.m
@@ -27,6 +27,12 @@
         return;
     }
     NSDictionary *options = (NSDictionary *)obj;
+    if (![[options objectForKey:@"tenantId"] isEqualToString:@""]) {
+        self.tenantId = [options objectForKey:@"tenantId"];
+    }
+    if (![[options objectForKey:@"clientId"] isEqualToString:@""]) {
+        self.clientId = [options objectForKey:@"clientId"];
+    }
     NSArray *authorities = [options objectForKey:@"authorities"];
     for (NSDictionary *a in authorities)
     {

--- a/www/msalplugin.js
+++ b/www/msalplugin.js
@@ -17,7 +17,9 @@ module.exports = {
             scopes: ['User.Read'],
             webViewZoomControlsEnabled: false,
             webViewZoomEnabled: false,
-            powerOptCheckForNetworkReqEnabled: true
+            powerOptCheckForNetworkReqEnabled: true,
+            clientId: '',
+            tenantId: ''
         }
         if (!options) {
             options = defaultOptions;
@@ -59,6 +61,12 @@ module.exports = {
             }
             if (typeof(options.scopes) == 'undefined') {
                 options.scopes = defaultOptions.scopes;
+            }            
+            if (typeof(options.clientId) == 'undefined') {
+                options.clientId = defaultOptions.clientId;
+            }
+            if (typeof(options.tenantId) == 'undefined') {
+                options.tenantId = defaultOptions.tenantId;
             }
         }
         cordova.exec(successCallback, errorCallback, 'MsalPlugin', 'msalInit', [JSON.stringify(options)]);


### PR DESCRIPTION
Hi @wrobins ! Here's another tweak I've made recently. I have an app that required the ability to switch between different tenant & client IDs at runtime based on which region the app discovered it was in.

These are all fully backwards compatible, so existing uses are unimpacted by the change, and no migration work is required. Simply the tenant and client IDs can be overridden during the `msalInit` call 🙂 